### PR TITLE
Writing requires: entries rather than externals...

### DIFF
--- a/freeze/cmd/freeze.py
+++ b/freeze/cmd/freeze.py
@@ -71,20 +71,20 @@ def freeze2(parser, args, outf, results):
     did_already = set()
     for spec in results:
         for dep in spec.traverse():
+
+            name = dep.name
+
             # don't export our externals
             if dep.external:
                 continue
-            path = dep.prefix
-            name = dep.name
-            requirebits =  dep.cformat(
-                "{name}:\n    require:\n    - '{@version}'\n    - '{variants}'\n    - '{%compiler.name}{@compiler.version}'"
-            )
-            # clean out build_system=xxx variants
-            requirebits = re.sub("'build_system=[^ ]*'", '' ,requirebits)
-            requirebits = re.sub("' - ''", "", requirebits)
 
             # gcc-runtime and glx are packages that shouldn't be exported
             if name in did_already or name == "gcc-runtime" or name == "glx":
                 continue
             did_already.add(name)
-            print( " ", requirebits, file=outf)
+
+            requirebits = dep.cformat(
+                "{name}:\n    require:\n    - '{@version}'\n    - '{variants}'\n    - '{%compiler.name}{@compiler.version}'"
+            )
+
+            print(" ", requirebits, file=outf)

--- a/freeze/cmd/freeze.py
+++ b/freeze/cmd/freeze.py
@@ -1,4 +1,5 @@
 import sys
+import re
 import os
 import spack.config
 import spack.cmd
@@ -73,13 +74,14 @@ def freeze2(parser, args, outf, results):
         for dep in spec.traverse():
             path = dep.prefix
             name = dep.name
-            specstr = dep.cformat(
-                "{name} {@version} {variants} {%compiler.name}{@compiler.version}"
+            requirebits =  dep.cformat(
+                "{name}:\n    require:\n    - '{@version}'\n    - '{variants}'\n    - '{%compiler.name}{@compiler.version}'"
             )
+            # clean out build_system=xxx variants
+            requirebits = re.sub("'build_system=[^ ]*'", '' ,requirebits)
+            requirebits = re.sub("' - ''", "", requirebits)
+
             if name in did_already:
                 continue
             did_already.add(name)
-            print(
-                f"  {name}:\n    externals:\n    - spec: {specstr}\n      prefix: {path}\n      buildable: false",
-                file=outf,
-            )
+            print( " ", requirebits, file=outf)


### PR DESCRIPTION
Writing external: entries  did not get proper references to the dependencies.  

This writes "requires:" blocks for what we're freezing and each dependency thereof.

It does not mark them buildable:false, as that sends the concretizer into waves of 
"trying to use nonexistent external for ..." errors. 

It should be easy enough to add more specificity if required. but experience to date shows that
such mods must be tested with at least a medium size dependency tree before you can conclude if it works... 